### PR TITLE
string: Remove restrict qualifier from parameters in header

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -8,7 +8,7 @@ __BEGIN_DECLS
 
 int memcmp(const void *, const void *, size_t);
 
-void *memcpy(void *restrict, const void *restrict, size_t);
+void *memcpy(void *, const void *, size_t);
 
 void *memmove(void *, const void *, size_t);
 


### PR DESCRIPTION
Having the restrict qualifier in the declaration is unnecessary and breaks c++ code including it.